### PR TITLE
Use bash to support all required commands

### DIFF
--- a/run-ktlint.sh
+++ b/run-ktlint.sh
@@ -10,7 +10,7 @@ SUCCESS_FILE="${CACHE}/download-finished-${VERSION}"
 LOCKFILE="${CACHE}/pre-commit-ktlint-download.lock"
 
 # make sure that lock file gets cleanup up in all cases
-trap 'rm -f ${LOCKFILE}' EXIT
+trap "rm -f ${LOCKFILE}" EXIT
 
 mkdir -p "${CACHE}"
 if [ ! -f "${SUCCESS_FILE}" ]

--- a/run-ktlint.sh
+++ b/run-ktlint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eu
 IFS=$'\n\t'
 


### PR DESCRIPTION
Shell on GitHub actions did not support the `exec` command. This enable the used of pre-commit in github actions.

With this a linting job can be configured as follows:
```
  lint:
    name: Linting
    runs-on: ubuntu-latest

    steps:
      - name: Checkout source
        uses: actions/checkout@v2

      - name: Setup Python
        uses: actions/setup-python@v2
        with:
          python-version: '3.8'

      - name: Update python environment
        run: |
          pip install --upgrade pre-commit

      - name: Run all linters
        run: pre-commit run --all-files
```