### PR TITLE
update to ktlint 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Usage:
 ```
 repos:
 - repo: https://github.com/tadodotcom/ktlint-pre-commit
-  rev: "0.45.2-1"
+  rev: "1.0.1"
   hooks:
       - id: ktlint
 ```
@@ -17,7 +17,7 @@ the hook as follows:
 ```
 repos:
 - repo: https://github.com/tadodotcom/ktlint-pre-commit
-  rev: "0.45.2-1"
+  rev: "1.0.1"
   hooks:
       - id: ktlint
         args: [-F]

--- a/run-ktlint.sh
+++ b/run-ktlint.sh
@@ -3,7 +3,7 @@ set -eu
 IFS=$'\n\t'
 
 REPOSITORY="https://github.com/pinterest/ktlint"
-VERSION=0.45.2
+VERSION=1.0.1
 CACHE=".cache"
 KTLINT="${CACHE}/ktlint-${VERSION}"
 SUCCESS_FILE="${CACHE}/download-finished-${VERSION}"


### PR DESCRIPTION
tado repositories using this hook can update to its latest version whenever they're ready, the update should not be automatic unless they specifically chose so during their set up. As per [documentation](https://pre-commit.com/#using-the-latest-version-for-a-repository):

> pre-commit configuration aims to give a repeatable and fast experience and therefore intentionally doesn't provide facilities for "unpinned latest version" for hook repositories. [...] pre-commit assumes that the value of [rev](https://pre-commit.com/#repos-rev) is an immutable ref (such as a tag or SHA) and will cache based on that. Using a branch name (or HEAD) for the value of [rev](https://pre-commit.com/#repos-rev) is not supported and will only represent the state of that mutable ref at the time of hook installation (and will NOT update automatically).

As far as I can tell all tado repositories using this hook have correctly defined a `rev` value:

https://github.com/search?q=org%3Atadodotcom%20https%3A%2F%2Fgithub.com%2Ftadodotcom%2Fktlint-pre-commit&type=code